### PR TITLE
feat: add array transformer for `define`

### DIFF
--- a/workspace/mauss/src/core/define/index.test.ts
+++ b/workspace/mauss/src/core/define/index.test.ts
@@ -59,8 +59,14 @@ type V<T> = (input: unknown) => T;
 			jp: r.optional(r.string()),
 		},
 		genres: r.array(r.string()),
-		rating: r.optional(r.number()),
-		completed: r.optional(r.number()),
+		rating: r.optional(
+			r.array(r.number(), (ratings) => {
+				const total = ratings.reduce((acc, cur) => +cur + acc, 0);
+				return Math.round((total / ratings.length + Number.EPSILON) * 100) / 100;
+			}),
+			-1,
+		),
+		completed: r.optional(r.string()),
 		verdict: r.literal('pending', 'not-recommended', 'contextual', 'recommended', 'must-watch'),
 
 		backdrop: r.optional(r.string()),
@@ -83,8 +89,8 @@ type V<T> = (input: unknown) => T;
 	expect<string>(metadata.title.en);
 	expect<undefined | string>(metadata.title.jp);
 	expect<string[]>(metadata.genres);
-	expect<undefined | number>(metadata.rating);
-	expect<undefined | number>(metadata.completed);
+	expect<number>(metadata.rating);
+	expect<undefined | string>(metadata.completed);
 	expect<'pending' | 'not-recommended' | 'contextual' | 'recommended' | 'must-watch'>(
 		metadata.verdict,
 	);

--- a/workspace/mauss/src/core/define/index.ts
+++ b/workspace/mauss/src/core/define/index.ts
@@ -18,10 +18,11 @@ function check(input: Record<string, unknown>, schema: Schema) {
 	}
 	return input;
 }
+
+type I<T> = T extends Validator<infer R> ? R : N<T>;
+type N<T> = T extends Record<string, any> ? { [K in keyof T]: I<T[K]> } : never;
 export function define<T>(builder: (r: typeof rules) => T) {
 	const schema = builder(rules) as Validator | Schema;
-	type I<T> = T extends Validator<infer R> ? R : N<T>;
-	type N<T> = T extends Record<string, any> ? { [K in keyof T]: I<T[K]> } : never;
 	return (input: unknown): I<T> => {
 		if (typeof schema === 'function') return schema(input) as I<T>;
 		return check(input as any, schema) as I<T>;

--- a/workspace/mauss/src/core/define/rules.ts
+++ b/workspace/mauss/src/core/define/rules.ts
@@ -49,13 +49,17 @@ export function date<T = Date>(transform?: (value: Date) => T): Validator<T> {
 		return transform ? transform(input) : (input as T);
 	};
 }
-export function array<T = unknown>(item: Validator<T>): Validator<T[]> {
+export function array<T, R = T[]>(
+	item: Validator<T>,
+	transform?: (values: T[]) => R,
+): Validator<R> {
 	return (input) => {
 		if (!Array.isArray(input)) throw new InputError('array', input);
-		return input.map((v) => item(v));
+		const result = input.map((v) => item(v));
+		return transform ? transform(result) : (result as R);
 	};
 }
-export function record<T = unknown>(value: Validator<T>): Validator<Record<string, T>> {
+export function record<T>(value: Validator<T>): Validator<Record<string, T>> {
 	return (input) => {
 		if (typeof input !== 'object') throw new InputError('record', input);
 		if (input == null) throw new InvalidInput('record', 'Received null or undefined');


### PR DESCRIPTION
also fixes the generated types for `define` by moving the scoped `type`s outside